### PR TITLE
Add assigned request flag to agent labels

### DIFF
--- a/src/metrics_agentpool.go
+++ b/src/metrics_agentpool.go
@@ -59,6 +59,7 @@ func (m *MetricsCollectorAgentPool) Setup(collector *CollectorAgentPool) {
 			"agentPoolAgentOs",
 			"enabled",
 			"status",
+			"hasAssignedRequest"
 		},
 	)
 
@@ -165,6 +166,7 @@ func (m *MetricsCollectorAgentPool) collectAgentQueues(ctx context.Context, call
 			"agentPoolAgentOs":      agentPoolAgent.OsDescription,
 			"enabled":               boolToString(agentPoolAgent.Enabled),
 			"status":                agentPoolAgent.Status,
+			"hasAssignedRequest":    boolToString(agentPoolAgent.AssignedRequest.RequestId > 0)
 		}
 
 		agentPoolAgentMetric.Add(infoLabels, 1)


### PR DESCRIPTION
Adds a `hasAssignedRequest` label to agents to help with querying agent pool utilisation.