### PR TITLE
By default the Azure DevOps REST API queries the first 100 projects

### DIFF
--- a/azure-devops-client/project.go
+++ b/azure-devops-client/project.go
@@ -29,7 +29,7 @@ func (c *AzureDevopsClient) ListProjects() (list ProjectList, error error) {
 	c.concurrencyLock()
 
 	url := fmt.Sprintf(
-		"_apis/projects?api-version=%v",
+		"_apis/projects?$top=300&api-version=%v",
 		url.QueryEscape(c.ApiVersion),
 	)
 	response, err := c.rest().R().Get(url)


### PR DESCRIPTION
By default the Azure DevOps REST API queries the first 100 projects, I am working in an organization with more than 100 projects. I put 300 because it is the top of projects in Azure DevOps

https://docs.microsoft.com/en-us/rest/api/azure/devops/core/projects/list?view=azure-devops-rest-5.1