### PR TITLE
Hotfix - Unsupported Protocol Scheme in VSRM Collectors.

### DIFF
--- a/azure-devops-client/main.go
+++ b/azure-devops-client/main.go
@@ -112,7 +112,7 @@ func (c *AzureDevopsClient) rest() *resty.Client {
 }
 
 func (c *AzureDevopsClient) restVsrm() *resty.Client {
-	if c.restClientVsrm == nil { 
+	if c.restClientVsrm == nil {
 		c.restClientVsrm = resty.New()
 		c.restClientVsrm.SetHostURL(fmt.Sprintf("https://vsrm.dev.azure.com/%v/", *c.organization))
 		c.restClientVsrm.SetHeader("Accept", "application/json")

--- a/azure-devops-client/main.go
+++ b/azure-devops-client/main.go
@@ -3,8 +3,9 @@ package AzureDevopsClient
 import (
 	"errors"
 	"fmt"
-	"gopkg.in/resty.v1"
 	"sync/atomic"
+
+	"gopkg.in/resty.v1"
 )
 
 type AzureDevopsClient struct {
@@ -111,20 +112,15 @@ func (c *AzureDevopsClient) rest() *resty.Client {
 }
 
 func (c *AzureDevopsClient) restVsrm() *resty.Client {
-	if c.restClientVsrm == nil {
+	if c.restClientVsrm == nil { 
 		c.restClientVsrm = resty.New()
-		if c.HostUrl != nil {
-			c.restClient.SetHostURL(*c.HostUrl)
-		} else {
-			c.restClientVsrm.SetHostURL(fmt.Sprintf("https://vsrm.dev.azure.com/%v/", *c.organization))
-		}
+		c.restClientVsrm.SetHostURL(fmt.Sprintf("https://vsrm.dev.azure.com/%v/", *c.organization))
 		c.restClientVsrm.SetHeader("Accept", "application/json")
 		c.restClientVsrm.SetBasicAuth("", *c.accessToken)
 		c.restClientVsrm.SetRetryCount(c.RequestRetries)
 		c.restClientVsrm.OnBeforeRequest(c.restOnBeforeRequest)
 		c.restClientVsrm.OnAfterResponse(c.restOnAfterResponse)
 	}
-
 	return c.restClientVsrm
 }
 


### PR DESCRIPTION
…was getting 404.

Resolves #31 

did some digging and found a couple things here..

This issue
```
RESTY 2021/02/19 17:04:08 ERROR Get "//%2foooo%2F_apis%2Frelease%2Freleases%3Fapi-version=5.1&isDeleted=false&$expand=94&minCreatedTime=2021-02-19T16%253A34%253A07Z&$top=100&queryOrder=descending/barrrrr/_apis/release/releases?api-version=5.1&isDeleted=false&$expand=94&minCreatedTime=2021-02-19T16%3A34%3A07Z&$top=100&queryOrder=descending": unsupported protocol scheme "", Attempt 2
```
Is caused by the [vsrmclient](https://github.com/webdevops/azure-devops-exporter/blob/main/azure-devops-client/main.go#L117) instantiation... `restClient.HostUrl`  is being set, but it should be `restClientVsrm.HostUrl`. 

We're getting protocol error b/c the hosturl is never set for our vsrm client, meaning there's no http/https.


After fixing the above I found that in the case where I have a vanity url for my org (foobar.visualstudio.com), I still needed to hit the VSTRM endpoint directly to get release data. Removing the if statement on L117 resolves both issues.
