### PR TITLE
Add new build timeline based metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ Metrics
 | `azure_devops_pullrequest_label`                | pullrequest   | Labels set on active PullRequests                                                    |
 | `azure_devops_build_info`                       | build         | Build informations                                                                   |
 | `azure_devops_build_status`                     | build         | Build status infos (queued, started, finished time)                                  |
+| `azure_devops_build_stage`                      | build         | Build stage infos (duration, errors, warnings, started, finished time)               |
+| `azure_devops_build_phase`                      | build         | Build phase infos (duration, errors, warnings, started, finished time)               |
+| `azure_devops_build_job`                        | build         | Build job infos (duration, errors, warnings, started, finished time)                 |
+| `azure_devops_build_task`                       | build         | Build task infos (duration, errors, warnings, started, finished time)                |
 | `azure_devops_build_definition_info`            | build         | Build definition info                                                                |
 | `azure_devops_release_info`                     | release       | Release informations                                                                 |
 | `azure_devops_release_artifact`                 | release       | Release artifcact informations                                                       |

--- a/metrics_build.go
+++ b/metrics_build.go
@@ -18,6 +18,11 @@ type MetricsCollectorBuild struct {
 
 		buildDefinition *prometheus.GaugeVec
 
+		buildStage *prometheus.GaugeVec
+		buildPhase *prometheus.GaugeVec
+		buildJob   *prometheus.GaugeVec
+		buildTask  *prometheus.GaugeVec
+
 		buildTimeProject *prometheus.SummaryVec
 		jobTimeProject   *prometheus.SummaryVec
 	}
@@ -64,6 +69,85 @@ func (m *MetricsCollectorBuild) Setup(collector *CollectorProject) {
 	)
 	prometheus.MustRegister(m.prometheus.buildStatus)
 
+	m.prometheus.buildStage = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "azure_devops_build_stage",
+			Help: "Azure DevOps build stages",
+		},
+		[]string{
+			"projectID",
+			"buildID",
+			"buildDefinitionID",
+			"buildNumber",
+			"name",
+			"id",
+			"identifier",
+			"result",
+			"type",
+		},
+	)
+	prometheus.MustRegister(m.prometheus.buildStage)
+
+	m.prometheus.buildPhase = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "azure_devops_build_phase",
+			Help: "Azure DevOps build phases",
+		},
+		[]string{
+			"projectID",
+			"buildID",
+			"buildDefinitionID",
+			"buildNumber",
+			"name",
+			"id",
+			"parentId",
+			"identifier",
+			"result",
+			"type",
+		},
+	)
+	prometheus.MustRegister(m.prometheus.buildPhase)
+
+	m.prometheus.buildJob = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "azure_devops_build_job",
+			Help: "Azure DevOps build jobs",
+		},
+		[]string{
+			"projectID",
+			"buildID",
+			"buildDefinitionID",
+			"buildNumber",
+			"name",
+			"id",
+			"parentId",
+			"identifier",
+			"result",
+			"type",
+		},
+	)
+	prometheus.MustRegister(m.prometheus.buildJob)
+
+	m.prometheus.buildTask = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "azure_devops_build_task",
+			Help: "Azure DevOps build tasks",
+		},
+		[]string{
+			"projectID",
+			"buildID",
+			"buildDefinitionID",
+			"buildNumber",
+			"name",
+			"id",
+			"parentId",
+			"workerName",
+			"result",
+			"type",
+		},
+	)
+	prometheus.MustRegister(m.prometheus.buildTask)
+
 	m.prometheus.buildDefinition = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "azure_devops_build_definition_info",
@@ -85,11 +169,16 @@ func (m *MetricsCollectorBuild) Reset() {
 	m.prometheus.build.Reset()
 	m.prometheus.buildDefinition.Reset()
 	m.prometheus.buildStatus.Reset()
+	m.prometheus.buildStage.Reset()
+	m.prometheus.buildPhase.Reset()
+	m.prometheus.buildJob.Reset()
+	m.prometheus.buildTask.Reset()
 }
 
 func (m *MetricsCollectorBuild) Collect(ctx context.Context, logger *log.Entry, callback chan<- func(), project devopsClient.Project) {
 	m.collectDefinition(ctx, logger, callback, project)
 	m.collectBuilds(ctx, logger, callback, project)
+	m.collectBuildsTimeline(ctx, logger, callback, project)
 }
 
 func (m *MetricsCollectorBuild) collectDefinition(ctx context.Context, logger *log.Entry, callback chan<- func(), project devopsClient.Project) {
@@ -190,5 +279,343 @@ func (m *MetricsCollectorBuild) collectBuilds(ctx context.Context, logger *log.E
 	callback <- func() {
 		buildMetric.GaugeSet(m.prometheus.build)
 		buildStatusMetric.GaugeSet(m.prometheus.buildStatus)
+	}
+}
+
+func (m *MetricsCollectorBuild) collectBuildsTimeline(ctx context.Context, logger *log.Entry, callback chan<- func(), project devopsClient.Project) {
+	minTime := time.Now().Add(-opts.Limit.BuildHistoryDuration)
+	list, err := AzureDevopsClient.ListBuildHistoryWithStatus(project.Id, minTime, "completed")
+	if err != nil {
+		logger.Error(err)
+		return
+	}
+
+	buildStageMetric := prometheusCommon.NewMetricsList()
+	buildPhaseMetric := prometheusCommon.NewMetricsList()
+	buildJobMetric := prometheusCommon.NewMetricsList()
+	buildTaskMetric := prometheusCommon.NewMetricsList()
+
+	for _, build := range list.List {
+		timelineRecordList, _ := AzureDevopsClient.ListBuildTimeline(project.Id, int64ToString(build.Id))
+		for _, timelineRecord := range timelineRecordList.List {
+			switch recordType := timelineRecord.RecordType; recordType {
+			case "Stage":
+				buildStageMetric.Add(prometheus.Labels{
+					"projectID":         project.Id,
+					"buildID":           int64ToString(build.Id),
+					"buildDefinitionID": int64ToString(build.Definition.Id),
+					"buildNumber":       build.BuildNumber,
+					"name":              timelineRecord.Name,
+					"id":                timelineRecord.Id,
+					"identifier":        timelineRecord.Identifier,
+					"result":            timelineRecord.Result,
+					"type":              "errorCount",
+				}, timelineRecord.ErrorCount)
+
+				buildStageMetric.Add(prometheus.Labels{
+					"projectID":         project.Id,
+					"buildID":           int64ToString(build.Id),
+					"buildDefinitionID": int64ToString(build.Definition.Id),
+					"buildNumber":       build.BuildNumber,
+					"name":              timelineRecord.Name,
+					"id":                timelineRecord.Id,
+					"identifier":        timelineRecord.Identifier,
+					"result":            timelineRecord.Result,
+					"type":              "warningCount",
+				}, timelineRecord.WarningCount)
+
+				buildStageMetric.AddBool(prometheus.Labels{
+					"projectID":         project.Id,
+					"buildID":           int64ToString(build.Id),
+					"buildDefinitionID": int64ToString(build.Definition.Id),
+					"buildNumber":       build.BuildNumber,
+					"name":              timelineRecord.Name,
+					"id":                timelineRecord.Id,
+					"identifier":        timelineRecord.Identifier,
+					"result":            timelineRecord.Result,
+					"type":              "succeeded",
+				}, timelineRecord.Result == "succeeded")
+
+				buildStageMetric.AddTime(prometheus.Labels{
+					"projectID":         project.Id,
+					"buildID":           int64ToString(build.Id),
+					"buildDefinitionID": int64ToString(build.Definition.Id),
+					"buildNumber":       build.BuildNumber,
+					"name":              timelineRecord.Name,
+					"id":                timelineRecord.Id,
+					"identifier":        timelineRecord.Identifier,
+					"result":            timelineRecord.Result,
+					"type":              "started",
+				}, timelineRecord.StartTime)
+
+				buildStageMetric.AddTime(prometheus.Labels{
+					"projectID":         project.Id,
+					"buildID":           int64ToString(build.Id),
+					"buildDefinitionID": int64ToString(build.Definition.Id),
+					"buildNumber":       build.BuildNumber,
+					"name":              timelineRecord.Name,
+					"id":                timelineRecord.Id,
+					"identifier":        timelineRecord.Identifier,
+					"result":            timelineRecord.Result,
+					"type":              "finished",
+				}, timelineRecord.FinishTime)
+
+				buildStageMetric.AddDuration(prometheus.Labels{
+					"projectID":         project.Id,
+					"buildID":           int64ToString(build.Id),
+					"buildDefinitionID": int64ToString(build.Definition.Id),
+					"buildNumber":       build.BuildNumber,
+					"name":              timelineRecord.Name,
+					"id":                timelineRecord.Id,
+					"identifier":        timelineRecord.Identifier,
+					"result":            timelineRecord.Result,
+					"type":              "duration",
+				}, timelineRecord.FinishTime.Sub(timelineRecord.StartTime))
+
+			case "Phase":
+				buildPhaseMetric.Add(prometheus.Labels{
+					"projectID":         project.Id,
+					"buildID":           int64ToString(build.Id),
+					"buildDefinitionID": int64ToString(build.Definition.Id),
+					"buildNumber":       build.BuildNumber,
+					"name":              timelineRecord.Name,
+					"id":                timelineRecord.Id,
+					"parentId":          timelineRecord.ParentId,
+					"identifier":        timelineRecord.Identifier,
+					"result":            timelineRecord.Result,
+					"type":              "errorCount",
+				}, timelineRecord.ErrorCount)
+
+				buildPhaseMetric.Add(prometheus.Labels{
+					"projectID":         project.Id,
+					"buildID":           int64ToString(build.Id),
+					"buildDefinitionID": int64ToString(build.Definition.Id),
+					"buildNumber":       build.BuildNumber,
+					"name":              timelineRecord.Name,
+					"id":                timelineRecord.Id,
+					"parentId":          timelineRecord.ParentId,
+					"identifier":        timelineRecord.Identifier,
+					"result":            timelineRecord.Result,
+					"type":              "warningCount",
+				}, timelineRecord.WarningCount)
+
+				buildPhaseMetric.AddBool(prometheus.Labels{
+					"projectID":         project.Id,
+					"buildID":           int64ToString(build.Id),
+					"buildDefinitionID": int64ToString(build.Definition.Id),
+					"buildNumber":       build.BuildNumber,
+					"name":              timelineRecord.Name,
+					"id":                timelineRecord.Id,
+					"parentId":          timelineRecord.ParentId,
+					"identifier":        timelineRecord.Identifier,
+					"result":            timelineRecord.Result,
+					"type":              "succeeded",
+				}, timelineRecord.Result == "succeeded")
+
+				buildPhaseMetric.AddTime(prometheus.Labels{
+					"projectID":         project.Id,
+					"buildID":           int64ToString(build.Id),
+					"buildDefinitionID": int64ToString(build.Definition.Id),
+					"buildNumber":       build.BuildNumber,
+					"name":              timelineRecord.Name,
+					"id":                timelineRecord.Id,
+					"parentId":          timelineRecord.ParentId,
+					"identifier":        timelineRecord.Identifier,
+					"result":            timelineRecord.Result,
+					"type":              "started",
+				}, timelineRecord.StartTime)
+
+				buildPhaseMetric.AddTime(prometheus.Labels{
+					"projectID":         project.Id,
+					"buildID":           int64ToString(build.Id),
+					"buildDefinitionID": int64ToString(build.Definition.Id),
+					"buildNumber":       build.BuildNumber,
+					"name":              timelineRecord.Name,
+					"id":                timelineRecord.Id,
+					"parentId":          timelineRecord.ParentId,
+					"identifier":        timelineRecord.Identifier,
+					"result":            timelineRecord.Result,
+					"type":              "finished",
+				}, timelineRecord.FinishTime)
+
+				buildPhaseMetric.AddDuration(prometheus.Labels{
+					"projectID":         project.Id,
+					"buildID":           int64ToString(build.Id),
+					"buildDefinitionID": int64ToString(build.Definition.Id),
+					"buildNumber":       build.BuildNumber,
+					"name":              timelineRecord.Name,
+					"id":                timelineRecord.Id,
+					"parentId":          timelineRecord.ParentId,
+					"identifier":        timelineRecord.Identifier,
+					"result":            timelineRecord.Result,
+					"type":              "duration",
+				}, timelineRecord.FinishTime.Sub(timelineRecord.StartTime))
+			case "Job":
+				buildJobMetric.Add(prometheus.Labels{
+					"projectID":         project.Id,
+					"buildID":           int64ToString(build.Id),
+					"buildDefinitionID": int64ToString(build.Definition.Id),
+					"buildNumber":       build.BuildNumber,
+					"name":              timelineRecord.Name,
+					"id":                timelineRecord.Id,
+					"parentId":          timelineRecord.ParentId,
+					"identifier":        timelineRecord.Identifier,
+					"result":            timelineRecord.Result,
+					"type":              "errorCount",
+				}, timelineRecord.ErrorCount)
+
+				buildJobMetric.Add(prometheus.Labels{
+					"projectID":         project.Id,
+					"buildID":           int64ToString(build.Id),
+					"buildDefinitionID": int64ToString(build.Definition.Id),
+					"buildNumber":       build.BuildNumber,
+					"name":              timelineRecord.Name,
+					"id":                timelineRecord.Id,
+					"parentId":          timelineRecord.ParentId,
+					"identifier":        timelineRecord.Identifier,
+					"result":            timelineRecord.Result,
+					"type":              "warningCount",
+				}, timelineRecord.WarningCount)
+
+				buildJobMetric.AddBool(prometheus.Labels{
+					"projectID":         project.Id,
+					"buildID":           int64ToString(build.Id),
+					"buildDefinitionID": int64ToString(build.Definition.Id),
+					"buildNumber":       build.BuildNumber,
+					"name":              timelineRecord.Name,
+					"id":                timelineRecord.Id,
+					"parentId":          timelineRecord.ParentId,
+					"identifier":        timelineRecord.Identifier,
+					"result":            timelineRecord.Result,
+					"type":              "succeeded",
+				}, timelineRecord.Result == "succeeded")
+
+				buildJobMetric.AddTime(prometheus.Labels{
+					"projectID":         project.Id,
+					"buildID":           int64ToString(build.Id),
+					"buildDefinitionID": int64ToString(build.Definition.Id),
+					"buildNumber":       build.BuildNumber,
+					"name":              timelineRecord.Name,
+					"id":                timelineRecord.Id,
+					"parentId":          timelineRecord.ParentId,
+					"identifier":        timelineRecord.Identifier,
+					"result":            timelineRecord.Result,
+					"type":              "started",
+				}, timelineRecord.StartTime)
+
+				buildJobMetric.AddTime(prometheus.Labels{
+					"projectID":         project.Id,
+					"buildID":           int64ToString(build.Id),
+					"buildDefinitionID": int64ToString(build.Definition.Id),
+					"buildNumber":       build.BuildNumber,
+					"name":              timelineRecord.Name,
+					"id":                timelineRecord.Id,
+					"parentId":          timelineRecord.ParentId,
+					"identifier":        timelineRecord.Identifier,
+					"result":            timelineRecord.Result,
+					"type":              "finished",
+				}, timelineRecord.FinishTime)
+
+				buildJobMetric.AddDuration(prometheus.Labels{
+					"projectID":         project.Id,
+					"buildID":           int64ToString(build.Id),
+					"buildDefinitionID": int64ToString(build.Definition.Id),
+					"buildNumber":       build.BuildNumber,
+					"name":              timelineRecord.Name,
+					"id":                timelineRecord.Id,
+					"parentId":          timelineRecord.ParentId,
+					"identifier":        timelineRecord.Identifier,
+					"result":            timelineRecord.Result,
+					"type":              "duration",
+				}, timelineRecord.FinishTime.Sub(timelineRecord.StartTime))
+			case "Task":
+				buildTaskMetric.Add(prometheus.Labels{
+					"projectID":         project.Id,
+					"buildID":           int64ToString(build.Id),
+					"buildDefinitionID": int64ToString(build.Definition.Id),
+					"buildNumber":       build.BuildNumber,
+					"name":              timelineRecord.Name,
+					"id":                timelineRecord.Id,
+					"parentId":          timelineRecord.ParentId,
+					"workerName":        timelineRecord.WorkerName,
+					"result":            timelineRecord.Result,
+					"type":              "errorCount",
+				}, timelineRecord.ErrorCount)
+
+				buildTaskMetric.Add(prometheus.Labels{
+					"projectID":         project.Id,
+					"buildID":           int64ToString(build.Id),
+					"buildDefinitionID": int64ToString(build.Definition.Id),
+					"buildNumber":       build.BuildNumber,
+					"name":              timelineRecord.Name,
+					"id":                timelineRecord.Id,
+					"parentId":          timelineRecord.ParentId,
+					"workerName":        timelineRecord.WorkerName,
+					"result":            timelineRecord.Result,
+					"type":              "warningCount",
+				}, timelineRecord.WarningCount)
+
+				buildTaskMetric.AddBool(prometheus.Labels{
+					"projectID":         project.Id,
+					"buildID":           int64ToString(build.Id),
+					"buildDefinitionID": int64ToString(build.Definition.Id),
+					"buildNumber":       build.BuildNumber,
+					"name":              timelineRecord.Name,
+					"id":                timelineRecord.Id,
+					"parentId":          timelineRecord.ParentId,
+					"workerName":        timelineRecord.WorkerName,
+					"result":            timelineRecord.Result,
+					"type":              "succeeded",
+				}, timelineRecord.Result == "succeeded")
+
+				buildTaskMetric.AddTime(prometheus.Labels{
+					"projectID":         project.Id,
+					"buildID":           int64ToString(build.Id),
+					"buildDefinitionID": int64ToString(build.Definition.Id),
+					"buildNumber":       build.BuildNumber,
+					"name":              timelineRecord.Name,
+					"id":                timelineRecord.Id,
+					"parentId":          timelineRecord.ParentId,
+					"workerName":        timelineRecord.WorkerName,
+					"result":            timelineRecord.Result,
+					"type":              "started",
+				}, timelineRecord.StartTime)
+
+				buildTaskMetric.AddTime(prometheus.Labels{
+					"projectID":         project.Id,
+					"buildID":           int64ToString(build.Id),
+					"buildDefinitionID": int64ToString(build.Definition.Id),
+					"buildNumber":       build.BuildNumber,
+					"name":              timelineRecord.Name,
+					"id":                timelineRecord.Id,
+					"parentId":          timelineRecord.ParentId,
+					"workerName":        timelineRecord.WorkerName,
+					"result":            timelineRecord.Result,
+					"type":              "finished",
+				}, timelineRecord.FinishTime)
+
+				buildTaskMetric.AddDuration(prometheus.Labels{
+					"projectID":         project.Id,
+					"buildID":           int64ToString(build.Id),
+					"buildDefinitionID": int64ToString(build.Definition.Id),
+					"buildNumber":       build.BuildNumber,
+					"name":              timelineRecord.Name,
+					"id":                timelineRecord.Id,
+					"parentId":          timelineRecord.ParentId,
+					"workerName":        timelineRecord.WorkerName,
+					"result":            timelineRecord.Result,
+					"type":              "duration",
+				}, timelineRecord.FinishTime.Sub(timelineRecord.StartTime))
+
+			}
+
+		}
+	}
+
+	callback <- func() {
+		buildStageMetric.GaugeSet(m.prometheus.buildStage)
+		buildPhaseMetric.GaugeSet(m.prometheus.buildPhase)
+		buildJobMetric.GaugeSet(m.prometheus.buildJob)
+		buildTaskMetric.GaugeSet(m.prometheus.buildTask)
 	}
 }


### PR DESCRIPTION
PR add new build metrics for better granularity level. New metric list:
azure_devops_build_stage Build stage infos (duration, errors, warnings, started, finished time)
azure_devops_build_phase Build phase infos (duration, errors, warnings, started, finished time)
azure_devops_build_job Build job infos (duration, errors, warnings, started, finished time)
azure_devops_build_task Build job infos (duration, errors, warnings, started, finished time)