### PR TITLE
Add result label for buildStatus metric

### DIFF
--- a/metrics_build.go
+++ b/metrics_build.go
@@ -59,6 +59,7 @@ func (m *MetricsCollectorBuild) Setup(collector *CollectorProject) {
 			"buildID",
 			"buildDefinitionID",
 			"buildNumber",
+			"result",
 			"type",
 		},
 	)
@@ -151,6 +152,7 @@ func (m *MetricsCollectorBuild) collectBuilds(ctx context.Context, logger *log.E
 			"buildID":           int64ToString(build.Id),
 			"buildDefinitionID": int64ToString(build.Definition.Id),
 			"buildNumber":       build.BuildNumber,
+			"result":            build.Result,
 			"type":              "succeeded",
 		}, build.Result == "succeeded")
 
@@ -159,6 +161,7 @@ func (m *MetricsCollectorBuild) collectBuilds(ctx context.Context, logger *log.E
 			"buildID":           int64ToString(build.Id),
 			"buildDefinitionID": int64ToString(build.Definition.Id),
 			"buildNumber":       build.BuildNumber,
+			"result":            build.Result,
 			"type":              "queued",
 		}, build.QueueTime)
 
@@ -167,6 +170,7 @@ func (m *MetricsCollectorBuild) collectBuilds(ctx context.Context, logger *log.E
 			"buildID":           int64ToString(build.Id),
 			"buildDefinitionID": int64ToString(build.Definition.Id),
 			"buildNumber":       build.BuildNumber,
+			"result":            build.Result,
 			"type":              "started",
 		}, build.StartTime)
 
@@ -175,6 +179,7 @@ func (m *MetricsCollectorBuild) collectBuilds(ctx context.Context, logger *log.E
 			"buildID":           int64ToString(build.Id),
 			"buildDefinitionID": int64ToString(build.Definition.Id),
 			"buildNumber":       build.BuildNumber,
+			"result":            build.Result,
 			"type":              "finished",
 		}, build.FinishTime)
 
@@ -183,6 +188,7 @@ func (m *MetricsCollectorBuild) collectBuilds(ctx context.Context, logger *log.E
 			"buildID":           int64ToString(build.Id),
 			"buildDefinitionID": int64ToString(build.Definition.Id),
 			"buildNumber":       build.BuildNumber,
+			"result":            build.Result,
 			"type":              "jobDuration",
 		}, build.FinishTime.Sub(build.StartTime))
 	}


### PR DESCRIPTION
PR adds `result` label on the `buildStatus` metrics, this could be helpful for getting build information based on build result status.