### PR TITLE
Fix an issue where the resty clients weren't initialized correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 /release-assets
 /azure-devops-exporter
 *.exe
+
+# VSCode
+.vscode/
+__debug_*

--- a/azure-devops-client/main.go
+++ b/azure-devops-client/main.go
@@ -160,8 +160,7 @@ func (c *AzureDevopsClient) SupportsPatAuthentication() bool {
 }
 
 func (c *AzureDevopsClient) rest() *resty.Client {
-
-	var client, err = c.restWithAuthentication(&c.restClient, "dev.azure.com")
+	var client, err = c.restWithAuthentication(c.restClient, "dev.azure.com")
 
 	if err != nil {
 		c.logger.Fatalf("could not create a rest client: %v", err)
@@ -171,8 +170,7 @@ func (c *AzureDevopsClient) rest() *resty.Client {
 }
 
 func (c *AzureDevopsClient) restVsrm() *resty.Client {
-
-	var client, err = c.restWithAuthentication(&c.restClientVsrm, "vsrm.dev.azure.com")
+	var client, err = c.restWithAuthentication(c.restClientVsrm, "vsrm.dev.azure.com")
 
 	if err != nil {
 		c.logger.Fatalf("could not create a rest client: %v", err)
@@ -181,14 +179,13 @@ func (c *AzureDevopsClient) restVsrm() *resty.Client {
 	return client
 }
 
-func (c *AzureDevopsClient) restWithAuthentication(restClient **resty.Client, domain string) (*resty.Client, error) {
-
-	if *restClient == nil {
-		*restClient = c.restWithoutToken(domain)
+func (c *AzureDevopsClient) restWithAuthentication(restClient *resty.Client, domain string) (*resty.Client, error) {
+	if restClient == nil {
+		restClient = c.restWithoutToken(domain)
 	}
 
 	if c.SupportsPatAuthentication() {
-		(*restClient).SetBasicAuth("", *c.accessToken)
+		restClient.SetBasicAuth("", *c.accessToken)
 	} else {
 		ctx := context.Background()
 		opts := policy.TokenRequestOptions{
@@ -199,10 +196,10 @@ func (c *AzureDevopsClient) restWithAuthentication(restClient **resty.Client, do
 			panic(err)
 		}
 
-		(*restClient).SetBasicAuth("", accessToken.Token)
+		restClient.SetBasicAuth("", accessToken.Token)
 	}
 
-	return (*restClient), nil
+	return restClient, nil
 }
 
 func (c *AzureDevopsClient) restWithoutToken(domain string) *resty.Client {

--- a/azure-devops-client/main.go
+++ b/azure-devops-client/main.go
@@ -160,7 +160,8 @@ func (c *AzureDevopsClient) SupportsPatAuthentication() bool {
 }
 
 func (c *AzureDevopsClient) rest() *resty.Client {
-	var client, err = c.restWithAuthentication("dev.azure.com")
+
+	var client, err = c.restWithAuthentication(&c.restClient, "dev.azure.com")
 
 	if err != nil {
 		c.logger.Fatalf("could not create a rest client: %v", err)
@@ -170,7 +171,8 @@ func (c *AzureDevopsClient) rest() *resty.Client {
 }
 
 func (c *AzureDevopsClient) restVsrm() *resty.Client {
-	var client, err = c.restWithAuthentication("vsrm.dev.azure.com")
+
+	var client, err = c.restWithAuthentication(&c.restClientVsrm, "vsrm.dev.azure.com")
 
 	if err != nil {
 		c.logger.Fatalf("could not create a rest client: %v", err)
@@ -179,13 +181,14 @@ func (c *AzureDevopsClient) restVsrm() *resty.Client {
 	return client
 }
 
-func (c *AzureDevopsClient) restWithAuthentication(domain string) (*resty.Client, error) {
-	if c.restClient == nil {
-		c.restClient = c.restWithoutToken(domain)
+func (c *AzureDevopsClient) restWithAuthentication(restClient **resty.Client, domain string) (*resty.Client, error) {
+
+	if *restClient == nil {
+		*restClient = c.restWithoutToken(domain)
 	}
 
 	if c.SupportsPatAuthentication() {
-		c.restClient.SetBasicAuth("", *c.accessToken)
+		(*restClient).SetBasicAuth("", *c.accessToken)
 	} else {
 		ctx := context.Background()
 		opts := policy.TokenRequestOptions{
@@ -196,10 +199,10 @@ func (c *AzureDevopsClient) restWithAuthentication(domain string) (*resty.Client
 			panic(err)
 		}
 
-		c.restClient.SetBasicAuth("", accessToken.Token)
+		(*restClient).SetBasicAuth("", accessToken.Token)
 	}
 
-	return c.restClient, nil
+	return (*restClient), nil
 }
 
 func (c *AzureDevopsClient) restWithoutToken(domain string) *resty.Client {


### PR DESCRIPTION
The `restWithAuthentication` function always only used `c.restClient`, even if a `c.restClientVsrm` was requested.

Fix it by passing pointers to the respective function.

Fixes #86

I tested the changes locally against our DevOps instance and I didn't see the 404 errors anymore