### PR TITLE
Add Continuation Token Support For Releases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #############################################
 # Build
 #############################################
-FROM --platform=$BUILDPLATFORM golang:1.23-alpine as build
+FROM --platform=$BUILDPLATFORM golang:1.23-alpine AS build
 
 RUN apk upgrade --no-cache --force
 RUN apk add --update build-base make git
@@ -21,7 +21,7 @@ RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} make build
 #############################################
 # Test
 #############################################
-FROM gcr.io/distroless/static as test
+FROM gcr.io/distroless/static AS test
 USER 0:0
 WORKDIR /app
 COPY --from=build /go/src/github.com/webdevops/azure-devops-exporter/azure-devops-exporter .
@@ -30,7 +30,7 @@ RUN ["./azure-devops-exporter", "--help"]
 #############################################
 # Final-static
 #############################################
-FROM gcr.io/distroless/static as final-static
+FROM gcr.io/distroless/static AS final-static
 ENV LOG_JSON=1
 WORKDIR /
 COPY --from=test /app .

--- a/azure-devops-client/release.go
+++ b/azure-devops-client/release.go
@@ -198,8 +198,6 @@ func (c *AzureDevopsClient) ListReleaseHistory(project string, minTime time.Time
 		return
 	}
 
-	fmt.Println(fmt.Sprintf("Length: %v", len(list.List)))
-
 	continuationToken := response.Header().Get("x-ms-continuationtoken")
 
 	for continuationToken != "" {

--- a/azure-devops-client/release.go
+++ b/azure-devops-client/release.go
@@ -191,11 +191,15 @@ func (c *AzureDevopsClient) ListReleaseHistory(project string, minTime time.Time
 		return
 	}
 
-	err = json.Unmarshal(response.Body(), &list)
+	var tmpReleases ReleaseList
+
+	err = json.Unmarshal(response.Body(), &tmpReleases)
 	if err != nil {
 		error = err
 		return
 	}
+
+	list = tmpReleases
 
 	return
 }

--- a/azure-devops-client/release.go
+++ b/azure-devops-client/release.go
@@ -222,7 +222,6 @@ func (c *AzureDevopsClient) ListReleaseHistory(project string, minTime time.Time
 
 		list.Count += tmpList.Count
 		list.List = append(list.List, tmpList.List...)
-		fmt.Println(fmt.Sprintf("Length: %v", len(list.List)))
 
 		continuationToken = response.Header().Get("x-ms-continuationtoken")
 	}

--- a/azure-devops-client/release.go
+++ b/azure-devops-client/release.go
@@ -185,14 +185,12 @@ func (c *AzureDevopsClient) ListReleaseHistory(project string, minTime time.Time
 		url.QueryEscape(minTime.Format(time.RFC3339)),
 		url.QueryEscape(int64ToString(c.LimitReleasesPerProject)),
 	)
-	// fmt.Println(fmt.Sprintf("-|-|-|-|-|-|-|-|-|-|-%v-|-|-|-|-|-|-|-|-|-|-",url))
+
 	response, err := c.restVsrm().R().Get(url)
 	if err := c.checkResponse(response, err); err != nil {
 		error = err
 		return
 	}
-
-	var tmpList ReleaseList
 
 	err = json.Unmarshal(response.Body(), &list)
 	if err != nil {
@@ -203,6 +201,7 @@ func (c *AzureDevopsClient) ListReleaseHistory(project string, minTime time.Time
 	fmt.Println(fmt.Sprintf("Length: %v", len(list.List)))
 
 	continuationToken := response.Header().Get("x-ms-continuationtoken")
+
 	for continuationToken != "" {
 		continuationUrl := fmt.Sprintf(
 			"%v&continuationToken=%v",
@@ -216,6 +215,7 @@ func (c *AzureDevopsClient) ListReleaseHistory(project string, minTime time.Time
 			return
 		}
 
+		var tmpList ReleaseList
 		err = json.Unmarshal(response.Body(), &tmpList)
 		if err != nil {
 			error = err

--- a/azure-devops-client/release.go
+++ b/azure-devops-client/release.go
@@ -185,21 +185,22 @@ func (c *AzureDevopsClient) ListReleaseHistory(project string, minTime time.Time
 		url.QueryEscape(minTime.Format(time.RFC3339)),
 		url.QueryEscape(int64ToString(c.LimitReleasesPerProject)),
 	)
+	// fmt.Println(fmt.Sprintf("-|-|-|-|-|-|-|-|-|-|-%v-|-|-|-|-|-|-|-|-|-|-",url))
 	response, err := c.restVsrm().R().Get(url)
 	if err := c.checkResponse(response, err); err != nil {
 		error = err
 		return
 	}
 
-	var tmpReleases ReleaseList
+	var tmpList ReleaseList
 
-	err = json.Unmarshal(response.Body(), &tmpReleases)
+	err = json.Unmarshal(response.Body(), &list)
 	if err != nil {
 		error = err
 		return
 	}
 
-	list = tmpReleases
+	fmt.Println(fmt.Sprintf("Length: %v", len(list.List)))
 
 	continuationToken := response.Header().Get("x-ms-continuationtoken")
 	for continuationToken != "" {
@@ -215,14 +216,15 @@ func (c *AzureDevopsClient) ListReleaseHistory(project string, minTime time.Time
 			return
 		}
 
-		err = json.Unmarshal(response.Body(), &tmpReleases)
+		err = json.Unmarshal(response.Body(), &tmpList)
 		if err != nil {
 			error = err
 			return
 		}
 
-		list.Count += tmpReleases.Count
-		list.List = append(list.List, tmpReleases.List...)
+		list.Count += tmpList.Count
+		list.List = append(list.List, tmpList.List...)
+		fmt.Println(fmt.Sprintf("Length: %v", len(list.List)))
 
 		continuationToken = response.Header().Get("x-ms-continuationtoken")
 	}

--- a/azure-devops-client/release.go
+++ b/azure-devops-client/release.go
@@ -201,5 +201,13 @@ func (c *AzureDevopsClient) ListReleaseHistory(project string, minTime time.Time
 
 	list = tmpReleases
 
+	continuationToken := response.Header().Get("x-ms-continuationtoken")
+	continuationUrl := fmt.Sprintf(
+		"%v&continuationToken=%v",
+		url,
+		continuationToken,
+	)
+	fmt.Println(continuationUrl)
+
 	return
 }

--- a/metrics_release.go
+++ b/metrics_release.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -46,7 +45,6 @@ func (m *MetricsCollectorRelease) Setup(collector *collector.Collector) {
 			"reason",
 			"result",
 			"url",
-			"counter",
 		},
 	)
 	m.Collector.RegisterMetricList("release", m.prometheus.release, true)
@@ -224,8 +222,6 @@ func (m *MetricsCollectorRelease) collectReleases(ctx context.Context, logger *z
 		return
 	}
 
-	counter := 0
-
 	for _, release := range releaseList.List {
 		releaseMetric.AddInfo(prometheus.Labels{
 			"projectID":           project.Id,
@@ -237,10 +233,7 @@ func (m *MetricsCollectorRelease) collectReleases(ctx context.Context, logger *z
 			"reason":              release.Reason,
 			"result":              to.BoolString(release.Result),
 			"url":                 release.Links.Web.Href,
-			"counter":             fmt.Sprintf("%d", counter),
 		})
-
-		counter++
 
 		for _, artifact := range release.Artifacts {
 			releaseArtifactMetric.AddInfo(prometheus.Labels{

--- a/metrics_release.go
+++ b/metrics_release.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -45,6 +46,7 @@ func (m *MetricsCollectorRelease) Setup(collector *collector.Collector) {
 			"reason",
 			"result",
 			"url",
+			"counter",
 		},
 	)
 	m.Collector.RegisterMetricList("release", m.prometheus.release, true)
@@ -222,6 +224,8 @@ func (m *MetricsCollectorRelease) collectReleases(ctx context.Context, logger *z
 		return
 	}
 
+	counter := 0
+
 	for _, release := range releaseList.List {
 		releaseMetric.AddInfo(prometheus.Labels{
 			"projectID":           project.Id,
@@ -233,7 +237,10 @@ func (m *MetricsCollectorRelease) collectReleases(ctx context.Context, logger *z
 			"reason":              release.Reason,
 			"result":              to.BoolString(release.Result),
 			"url":                 release.Links.Web.Href,
+			"counter":             fmt.Sprintf("%d", counter),
 		})
+
+		counter++
 
 		for _, artifact := range release.Artifacts {
 			releaseArtifactMetric.AddInfo(prometheus.Labels{


### PR DESCRIPTION
As the official REST API for listing releases only supports returning up to 100 results per request (even with $Top values greater than 100), the API returns a continuation token in the "x-ms-continuationtoken" response header.

https://learn.microsoft.com/en-us/rest/api/azure/devops/release/releases/list?view=azure-devops-server-rest-7.0&tabs=HTTP

![image](https://github.com/user-attachments/assets/a4873d98-a43d-4bf6-8d09-192318f995bc)

This PR introduces support to loop sending GET requests to the endpoint and passing the continuation token received (if any) along in the query string parameters. For a sufficiently large time period, this raises the limit of the number of results returned from 100 to the real value.

Before:
![image](https://github.com/user-attachments/assets/c36066dc-b372-4a4d-bb84-02c42b564c71)

After:
![image](https://github.com/user-attachments/assets/7a749c47-8ba7-49fd-9bad-b3b52eff4a62)

--

I'm happy to extend this functionality to other endpoints that require continuation tokens if this PR gets approval.

---
Also changes the case of the 3 `as` statements in the dockerfile to mitigate the build warnings.
