### PR TITLE
Add Agent's Computer Name to metric

### DIFF
--- a/azure-devops-client/agentpool.go
+++ b/azure-devops-client/agentpool.go
@@ -161,7 +161,7 @@ func (c *AzureDevopsClient) ListAgentPoolAgents(agentPoolId int64) (list AgentPo
 	c.concurrencyLock()
 
 	url := fmt.Sprintf(
-		"/_apis/distributedtask/pools/%v/agents?includeCapabilities=false&includeAssignedRequest=true",
+		"/_apis/distributedtask/pools/%v/agents?includeCapabilities=true&includeAssignedRequest=true",
 		fmt.Sprintf("%d", agentPoolId),
 	)
 	response, err := c.rest().R().Get(url)

--- a/azure-devops-client/agentpool.go
+++ b/azure-devops-client/agentpool.go
@@ -110,6 +110,7 @@ type AgentPoolAgent struct {
 	Version           string
 	CreatedOn         time.Time
 	AssignedRequest   JobRequest
+	SystemCapabilities map[string]string
 }
 
 type JobRequest struct {

--- a/azure-devops-client/agentpool.go
+++ b/azure-devops-client/agentpool.go
@@ -100,17 +100,17 @@ type AgentPoolAgentList struct {
 }
 
 type AgentPoolAgent struct {
-	Id                int64
-	Enabled           bool
-	MaxParallelism    int64
-	Name              string
-	OsDescription     string
-	ProvisioningState string
-	Status            string
-	Version           string
-	CreatedOn         time.Time
-	AssignedRequest   JobRequest
+	Id                 int64
+	Enabled            bool
+	MaxParallelism     int64
+	Name               string
+	OsDescription      string
 	SystemCapabilities map[string]string
+	ProvisioningState  string
+	Status             string
+	Version            string
+	CreatedOn          time.Time
+	AssignedRequest    JobRequest
 }
 
 type JobRequest struct {

--- a/azure-devops-client/agentpool.go
+++ b/azure-devops-client/agentpool.go
@@ -161,7 +161,7 @@ func (c *AzureDevopsClient) ListAgentPoolAgents(agentPoolId int64) (list AgentPo
 	c.concurrencyLock()
 
 	url := fmt.Sprintf(
-		"/_apis/distributedtask/pools/%v/agents?includeCapabilities=false&demands=Agent.ComputerName&includeAssignedRequest=true",
+		"/_apis/distributedtask/pools/%v/agents?includeCapabilities=true&includeAssignedRequest=true",
 		fmt.Sprintf("%d", agentPoolId),
 	)
 	response, err := c.rest().R().Get(url)

--- a/azure-devops-client/agentpool.go
+++ b/azure-devops-client/agentpool.go
@@ -161,7 +161,7 @@ func (c *AzureDevopsClient) ListAgentPoolAgents(agentPoolId int64) (list AgentPo
 	c.concurrencyLock()
 
 	url := fmt.Sprintf(
-		"/_apis/distributedtask/pools/%v/agents?includeCapabilities=true&includeAssignedRequest=true",
+		"/_apis/distributedtask/pools/%v/agents?includeCapabilities=false&demands=Agent.ComputerName&includeAssignedRequest=true",
 		fmt.Sprintf("%d", agentPoolId),
 	)
 	response, err := c.rest().R().Get(url)

--- a/metrics_agentpool.go
+++ b/metrics_agentpool.go
@@ -184,17 +184,17 @@ func (m *MetricsCollectorAgentPool) collectAgentQueues(ctx context.Context, logg
 	for _, agentPoolAgent := range list.List {
 		agentPoolSize++
 		infoLabels := prometheus.Labels{
-			"agentPoolID":           int64ToString(agentPoolId),
-			"agentPoolAgentID":      int64ToString(agentPoolAgent.Id),
-			"agentPoolAgentName":    agentPoolAgent.Name,
-			"agentPoolAgentVersion": agentPoolAgent.Version,
-			"provisioningState":     agentPoolAgent.ProvisioningState,
-			"maxParallelism":        int64ToString(agentPoolAgent.MaxParallelism),
-			"agentPoolAgentOs":      agentPoolAgent.OsDescription,
-			"enabled":               to.BoolString(agentPoolAgent.Enabled),
-			"status":                agentPoolAgent.Status,
-			"hasAssignedRequest":    to.BoolString(agentPoolAgent.AssignedRequest.RequestId > 0),
+			"agentPoolID":                int64ToString(agentPoolId),
+			"agentPoolAgentID":           int64ToString(agentPoolAgent.Id),
+			"agentPoolAgentName":         agentPoolAgent.Name,
+			"agentPoolAgentVersion":      agentPoolAgent.Version,
+			"provisioningState":          agentPoolAgent.ProvisioningState,
+			"maxParallelism":             int64ToString(agentPoolAgent.MaxParallelism),
+			"agentPoolAgentOs":           agentPoolAgent.OsDescription,
 			"agentPoolAgentComputerName": agentPoolAgent.SystemCapabilities["Agent.ComputerName"],
+			"enabled":                    to.BoolString(agentPoolAgent.Enabled),
+			"status":                     agentPoolAgent.Status,
+			"hasAssignedRequest":         to.BoolString(agentPoolAgent.AssignedRequest.RequestId > 0),
 		}
 
 		agentPoolAgentMetric.Add(infoLabels, 1)

--- a/metrics_agentpool.go
+++ b/metrics_agentpool.go
@@ -77,6 +77,7 @@ func (m *MetricsCollectorAgentPool) Setup(collector *collector.Collector) {
 			"provisioningState",
 			"maxParallelism",
 			"agentPoolAgentOs",
+			"agentPoolAgentComputerName",
 			"enabled",
 			"status",
 			"hasAssignedRequest",
@@ -193,6 +194,7 @@ func (m *MetricsCollectorAgentPool) collectAgentQueues(ctx context.Context, logg
 			"enabled":               to.BoolString(agentPoolAgent.Enabled),
 			"status":                agentPoolAgent.Status,
 			"hasAssignedRequest":    to.BoolString(agentPoolAgent.AssignedRequest.RequestId > 0),
+			"agentPoolAgentComputerName": agentPoolAgent.SystemCapabilities["Agent.ComputerName"],
 		}
 
 		agentPoolAgentMetric.Add(infoLabels, 1)


### PR DESCRIPTION
This PR augments the `azure_devops_agentpool_agent_info` metric by adding the agent's computer name as a label.
This can be useful for grouping agents by the server that they're running on for use in Grafana dashboards. Whilst I personally prefer the term "Server Name", "Computer Name" was chosen as it more closely matches the capability that is exposed by the Agent Software (Agent.ComputerName).

---
![image](https://github.com/user-attachments/assets/9f5825dc-7045-4cd4-9b45-791b6ac6917f)
