### PR TITLE
Add agent system capabilities to azure_devops_agentpool_agent_info

### DIFF
--- a/metrics_agentpool.go
+++ b/metrics_agentpool.go
@@ -77,7 +77,7 @@ func (m *MetricsCollectorAgentPool) Setup(collector *collector.Collector) {
 			"provisioningState",
 			"maxParallelism",
 			"agentPoolAgentOs",
-			"agentPoolAgentComputerName",
+			"agentPoolAgentSystemCapabilities",
 			"enabled",
 			"status",
 			"hasAssignedRequest",
@@ -184,11 +184,6 @@ func (m *MetricsCollectorAgentPool) collectAgentQueues(ctx context.Context, logg
 	for _, agentPoolAgent := range list.List {
 		agentPoolSize++
 
-		agentComputerName := ""
-		if val, exists := agentPoolAgent.SystemCapabilities["Agent.ComputerName"]; exists {
-			agentComputerName = val
-		}
-
 		infoLabels := prometheus.Labels{
 			"agentPoolID":                int64ToString(agentPoolId),
 			"agentPoolAgentID":           int64ToString(agentPoolAgent.Id),
@@ -197,7 +192,7 @@ func (m *MetricsCollectorAgentPool) collectAgentQueues(ctx context.Context, logg
 			"provisioningState":          agentPoolAgent.ProvisioningState,
 			"maxParallelism":             int64ToString(agentPoolAgent.MaxParallelism),
 			"agentPoolAgentOs":           agentPoolAgent.OsDescription,
-			"agentPoolAgentComputerName": agentComputerName,
+			"agentPoolAgentSystemCapabilities": agentPoolAgent.SystemCapabilities,
 			"enabled":                    to.BoolString(agentPoolAgent.Enabled),
 			"status":                     agentPoolAgent.Status,
 			"hasAssignedRequest":         to.BoolString(agentPoolAgent.AssignedRequest.RequestId > 0),


### PR DESCRIPTION
#115 introduced agent computer name by pulling agent system capabilities to the exporter. 
I believe many people would need more than just the computer name - we could pull all the agent system capabilities.